### PR TITLE
Add precedence test for ISO week calculation

### DIFF
--- a/tests/test_data_processing.py
+++ b/tests/test_data_processing.py
@@ -80,3 +80,14 @@ def test_earliest_sensor_timestamp_used():
     s2 = SensorDataModel(trip_id=trip_id, timestamp="2024-02-04T12:00:00Z")
     result = process_and_aggregate_data([trip], [s1, s2])[0]
     assert result["week"] == "2024-W05"
+
+def test_start_time_priority_over_sensor():
+    trip_id = uuid4()
+    trip = TripModel(
+        id=trip_id,
+        driverProfileId=uuid4(),
+        start_time="2024-02-07T00:00:00Z",
+    )
+    sensor = SensorDataModel(trip_id=trip_id, timestamp="2024-02-01T00:00:00Z")
+    result = process_and_aggregate_data([trip], [sensor])[0]
+    assert result["week"] == "2024-W06"


### PR DESCRIPTION
## Summary
- ensure that a trip's `start_time` overrides sensor timestamps when computing ISO week

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857778888f08332b2a635dccd4e433b