### PR TITLE
Handle week strings with or without 'W' separator

### DIFF
--- a/app/routers/ubpk_metrics.py
+++ b/app/routers/ubpk_metrics.py
@@ -37,8 +37,27 @@ router = APIRouter()
 
 
 def parse_iso_week(week: str) -> tuple[date, date]:
-    year, week_no = week.split("-W")
-    year, week_no = int(year), int(week_no)
+    """Parse a week string and return the start and end dates.
+
+    The API historically accepted both ``YYYY-Www`` and ``YYYY-WW`` formats
+    (with or without the ``W`` separator).  To be resilient against either
+    input, this helper now checks for both patterns before raising an error.
+    """
+
+    week = week.strip()
+
+    if "-W" in week:
+        parts = week.split("-W")
+    elif "-" in week:
+        parts = week.split("-")
+    else:
+        raise HTTPException(status_code=400, detail="Invalid week format")
+
+    if len(parts) != 2:
+        raise HTTPException(status_code=400, detail="Invalid week format")
+
+    year, week_no = int(parts[0]), int(parts[1])
+
     start = date.fromisocalendar(year, week_no, 1)
     return start, start + timedelta(days=7)
 

--- a/tests/test_ubpk_metrics.py
+++ b/tests/test_ubpk_metrics.py
@@ -95,3 +95,10 @@ def test_driver_improvement(monkeypatch):
     monkeypatch.setattr(ubpk_metrics, '_trip_behaviour_counts', fake_beh)
     res = ubpk_metrics.driver_improvement(driver, None)
     assert 'p_value' in res and 'mean_difference' in res
+
+
+def test_parse_iso_week_both_formats():
+    start1, end1 = ubpk_metrics.parse_iso_week("2024-W06")
+    start2, end2 = ubpk_metrics.parse_iso_week("2024-06")
+    assert start1 == start2
+    assert end1 == end2


### PR DESCRIPTION
## Summary
- handle `parse_iso_week` inputs that may lack the `W` separator
- test parsing of both week formats

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68589eff2c0483328b6859d0fb24641c